### PR TITLE
ReferenceError: sessionStorage is not defined fix

### DIFF
--- a/src/NgForage/session-storage/_isSessionStorageUsable.ts
+++ b/src/NgForage/session-storage/_isSessionStorageUsable.ts
@@ -2,13 +2,5 @@ import {checkIfSessionStorageThrows} from './checkIfSessionStorageThrows';
 
 /** @internal */
 export function _isSessionStorageUsable() {
-    if (typeof sessionStorage !== 'undefined') {
-        if( !checkIfSessionStorageThrows() || sessionStorage.length > 0) {
-            return true;
-        } else {
-            return false;
-        }
-    } else {
-        return false
-    }
+    return typeof sessionStorage !== 'undefined' && (!checkIfSessionStorageThrows() || sessionStorage.length > 0);
 }

--- a/src/NgForage/session-storage/_isSessionStorageUsable.ts
+++ b/src/NgForage/session-storage/_isSessionStorageUsable.ts
@@ -2,5 +2,13 @@ import {checkIfSessionStorageThrows} from './checkIfSessionStorageThrows';
 
 /** @internal */
 export function _isSessionStorageUsable() {
-  return typeof sessionStorage !== 'undefined' && !checkIfSessionStorageThrows() || sessionStorage.length > 0;
+    if (typeof sessionStorage !== 'undefined') {
+        if( !checkIfSessionStorageThrows() || sessionStorage.length > 0) {
+            return true;
+        } else {
+            return false;
+        }
+    } else {
+        return false
+    }
 }


### PR DESCRIPTION
`ReferenceError: sessionStorage is not defined` fix.

Checked on Angular 5.2.9 with Angular Universal and is working fine.